### PR TITLE
Create add practitioner skill

### DIFF
--- a/.claude/commands/add-practitioner.md
+++ b/.claude/commands/add-practitioner.md
@@ -1,0 +1,391 @@
+Add a new practitioner to the website using data from `data/practitioners/$ARGUMENTS.json`.
+
+Read that JSON file first, then perform every step below in order.
+
+---
+
+## Step 1 — Parse the JSON
+
+Extract all fields. Derive these additional values:
+- `full_name` = `{first_name} {last_name}`
+- `slug` = `image_key` (used for file paths and URLs, e.g. `ada_chindah`)
+- `img_sml` = `{s3_base_url}/images/profile/sml/{image_key}.jpg`
+- `img_med` = `{s3_base_url}/images/profile/med/{image_key}.jpg`
+- `img_lrg` = `{s3_base_url}/images/profile/lrg/{image_key}.jpg`
+- `css_classes` = space-joined CSS filter classes for each service (see mapping below)
+- `profile_url_from_root` = `profiles/{slug}`
+- `profile_url_from_service` = `../profiles/{slug}`
+
+**Service → CSS class + service page + icon + label mapping:**
+
+| `services` value | CSS class    | Service page                  | Icon filename              | Sidebar label                    |
+|------------------|--------------|-------------------------------|----------------------------|----------------------------------|
+| `massage`        | `rmt`        | `service/massage.php`         | `massage-icon.jpg`         | `Registered Massage Therapy`     |
+| `chiropractic`   | `chiro`      | `service/chiropractic.php`    | `chiro-icon.jpg`           | `Chiropractic Services`          |
+| `physiotherapy`  | `physio`     | `service/physiotherapy.php`   | `physio-icon.jpg`          | `Physiotherapy`                  |
+| `acupuncture`    | `acupuncture`| `service/acupuncture.php`     | `acupuncture-icon.jpg`     | `Acupuncture`                    |
+| `sports-massage` | `rmt`        | `service/sports-massage.php`  | `massage-icon.jpg`         | `Sports Massage Therapy`         |
+| `telehealth`     | `telehealth` | `service/telehealth.php`      | `telehealth-icon.jpg`      | `Virtual Telehealth`             |
+
+`css_classes` is all matched CSS classes joined with a space, e.g. `rmt chiro` for `["massage","chiropractic"]`.
+
+Icons are served from `https://s3.ca-central-1.amazonaws.com/nexusmassageclinic/icons/{icon_filename}`.
+
+---
+
+## Step 2 — Create `profiles/{slug}.php`
+
+Create the file using this exact template, substituting all `{{ }}` placeholders:
+
+```php
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Title -->
+  <title>{{ seo.title }}</title>
+
+  <meta name="Description" content="{{ seo.description }}">
+  <meta name="keywords" content="{{ seo.keywords }}">
+
+  <!-- Common Header -->
+  <?php include('../includes/common-header.php') ?>
+  <!-- End Common Header -->
+
+  <style>
+    @media (min-width: 768px) {
+      .custom-top-spacing {
+        padding-top: 8.125rem;
+      }
+    }
+    @media (max-width: 1024px) {
+      .custom-top-spacing {
+        padding-top: 15rem;
+      }
+    }
+  </style>
+
+</head>
+
+<body>
+
+  <!-- ========== HEADER ========== -->
+  <?php include('../includes/nav.php') ?>
+  <!-- ========== END HEADER ========== -->
+
+  <!-- ========== MAIN ========== -->
+  <main id="content" role="main">
+
+    <!-- Author Section -->
+    <div class="position-relative text-center custom-top-spacing u-gradient-overlay-half-info-v1 u-bg-img-hero">
+      <div class="row justify-content-md-center">
+
+        <div class="col-md-8 col-lg-7 col-xl-5">
+
+          <div class="animated bounceIn">
+          <!-- Info -->
+          <div class="mb-4">
+            <h1 class="display-4 font-size-48--md-down text-white font-weight-bold">{{ display_name | uppercase }}</h1>
+          </div>
+
+          <ul class="list-inline">
+            <li class="list-inline-item">
+              <a class="u-text-light" href="mailto:{{ email }}">
+                <span class="far fa-envelope mr-2"></span>
+                {{ email }}
+              </a>
+            </li>
+          </ul>
+          <!-- End Info -->
+
+          <!-- Avatar -->
+          <img class="img-fluid u-xl-avatar u-xl-avatar--bordered u-avatar-v1 rounded-circle mx-auto" src="{{ img_med }}" alt="{{ display_name }} - Profile">
+          <!-- End Avatar -->
+          </div>
+        </div>
+
+        <!-- SVG Background -->
+        <figure class="position-absolute-bottom-0 z-index-minus-1">
+          <svg preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+            width="100%" height="200px" viewBox="20 -20 300 100" style="margin-bottom: -8px;" xml:space="preserve">
+            <path class="u-fill-white" opacity="0.4" d="M30.913,43.944c0,0,42.911-34.464,87.51-14.191c77.31,35.14,113.304-1.952,146.638-4.729
+              c48.654-4.056,69.94,16.218,69.94,16.218v54.396H30.913V43.944z" />
+            <path class="u-fill-white" opacity="0.4" d="M-35.667,44.628c0,0,42.91-34.463,87.51-14.191c77.31,35.141,113.304-1.952,146.639-4.729
+              c48.653-4.055,69.939,16.218,69.939,16.218v54.396H-35.667V44.628z" />
+            <path class="u-fill-white" opacity="0" d="M43.415,98.342c0,0,48.283-68.927,109.133-68.927c65.886,0,97.983,67.914,97.983,67.914v3.716
+              H42.401L43.415,98.342z" />
+            <path class="u-fill-white" d="M-34.667,62.998c0,0,56-45.667,120.316-27.839C167.484,57.842,197,41.332,232.286,30.428
+              c53.07-16.399,104.047,36.903,104.047,36.903l1.333,36.667l-372-2.954L-34.667,62.998z" />
+          </svg>
+        </figure>
+        <!-- End SVG Background Section -->
+      </div>
+
+    </div>
+    <!-- End Author Section -->
+
+
+
+    <!-- Content Section -->
+    <div class="u-bg-light-blue-50">
+      <div class="container u-space-2">
+        <div class="row">
+          <div class="col-lg-3 mb-7 mb-lg-0">
+            <!-- Profile Card -->
+            <div class="card p-1 mb-4" style="min-width: 225px;">
+              <div class="card-body text-center">
+                <div class="mb-2">
+
+                  <a class="btn btn-block btn-danger transition-3d-hover" href="https://nexusclinic.clinicsense.com/book/" target="_blank" onclick="handleClick('sidebarBtn');">Book Practitioner<span class="fa fa-angle-right ml-2"></span></a>
+                  <br>
+
+                  <a class="btn btn-block u-btn-primary--air transition-3d-hover" href="mailto:{{ email }}">
+                    <span class="far fa-envelope mr-2"></span>
+                    Send a Message
+                  </a>
+                </div>
+              </div>
+            </div>
+            <!-- End Profile Card -->
+
+            <!-- Contacts  -->
+            <div class="card p-1 mb-4" style="min-width: 225px;">
+              <div class="card-body">
+                <h4 class="h6 mb-0 font-weight-bold">SERVICES:</h4>
+
+                <hr>
+
+                {{ SERVICES_SIDEBAR }}
+
+              </div>
+            </div>
+            <!-- End Contacts  -->
+
+            <!-- Hours  -->
+            <div class="card p-1 mb-4" style="min-width: 225px;">
+              <div class="card-body">
+                <h4 class="h6 mb-0 font-weight-bold">HOURS OF AVAILABILITY:</h4>
+
+                <hr>
+
+                <!-- User -->
+                <span class="d-flex align-items-start">
+
+                  <div class="ml-2">
+                    {{ HOURS_ROWS }}
+                  </div>
+                </span>
+                <!-- End User -->
+                  
+              </div>
+            </div>
+            <!-- End Hours  -->
+
+          </div>
+
+          <div class="col-lg-9">
+              <!-- Title -->
+              <div class="mb-3">
+                <h5 class="text-primary font-weight-bold">Tell us about yourself?</h5>
+              </div>
+              <!-- End Title -->
+
+              <!-- Text -->
+              {{ bio.about | paragraphs }}
+              <!-- End Text -->
+
+              <!-- Title -->
+              <div class="mb-3">
+                <h5 class="text-primary font-weight-bold">Which cases do you enjoy treating? Why?</h5>
+              </div>
+              <!-- End Title -->
+
+              <!-- Text -->
+              {{ bio.cases | paragraphs }}
+              <!-- End Text -->
+
+              <!-- Title -->
+              <div class="mb-3">
+                <h5 class="text-primary font-weight-bold">What are the top 3 treatments that you specialize in?</h5>
+              </div>
+              <!-- End Title -->
+
+              <!-- Text -->
+              {{ bio.specializations | paragraphs }}
+              <!-- End Text -->
+
+              <!-- Title -->
+              <div class="mb-3">
+                <h5 class="text-primary font-weight-bold">What are you proud of in your practice?</h5>
+              </div>
+              <!-- End Title -->
+
+              <!-- Text -->
+              {{ bio.proud_of | paragraphs }}
+              <!-- End Text -->
+
+              <!-- Title -->
+              <div class="mb-3">
+                <h5 class="text-primary font-weight-bold">Why should patients choose you as their provider instead of others in the area?</h5>
+              </div>
+              <!-- End Title -->
+
+              <!-- Text -->
+              {{ bio.why_choose | paragraphs }}
+              <!-- End Text -->
+
+          </div>
+
+        </div>
+
+      </div>
+    </div>
+    <!-- End Content Section -->
+
+    <!-- Social Section -->
+    <div class="u-bg-light-blue-50 u-space-2-bottom">
+      <div class="container">
+        <!-- Review Widget -->
+        
+        <div class="embedsocial-reviews" data-ref="0c8cb12f4327698a9a08fed0accae436258c57d2"></div> <script> (function(d, s, id){ var js; if (d.getElementById(id)) {return;} js = d.createElement(s); js.id = id; js.src = "https://embedsocial.com/embedscript/ri.js"; d.getElementsByTagName("head")[0].appendChild(js); }(document, "script", "EmbedSocialReviewsScript")); </script>
+
+        <!-- End Review Widget -->
+      </div>
+    </div>
+
+  </main>
+  <!-- ========== END MAIN ========== -->
+
+  <!-- ========== FOOTER ========== -->
+  <?php include('../includes/footer.php')?>
+  <!-- ========== END FOOTER ========== -->
+
+  <!-- Common Footer -->
+  <?php include('../includes/common-footer.php') ?>
+  <!-- End Common Footer -->
+
+</body>
+</html>
+```
+
+### Placeholder expansion rules
+
+**`{{ display_name | uppercase }}`** — the display_name value in ALL CAPS.
+
+**Multi-paragraph bio fields** — any `bio.*` field may contain `\n\n` to delimit paragraphs. When rendering, split the value on `\n\n` and wrap each chunk in its own `<p>` tag instead of a single `<p>`. For example, a field with two paragraphs becomes:
+```html
+              <p>First paragraph text.</p>
+              <p>Second paragraph text.</p>
+```
+
+**`{{ SERVICES_SIDEBAR }}`** — one block per service, in the order listed in `services`:
+```html
+                <!-- User -->
+                <div class="card-header border-0 py-3 d-flex align-items-center">
+                  <img src="https://s3.ca-central-1.amazonaws.com/nexusmassageclinic/icons/{icon_filename}" class="rounded-circle u-avatar align-self-start mr-3">
+                  <div>
+                    <a href="../service/{service_slug}">
+                      <span class="d-block text-dark small font-weight-bold">{sidebar_label}</span>
+                    </a>
+                  </div>
+                </div>
+                <!-- End User -->
+```
+where `{service_slug}` is the value from the `services` array (e.g. `massage`, `chiropractic`).
+
+**`{{ HOURS_ROWS }}`** — one `<p>` per entry in `hours`:
+```html
+                    <p class="text-dark"><strong>{day}:</strong><span class="ml-3"></span>{time}</p>
+```
+
+---
+
+## Step 3 — Update `team.php`
+
+Insert the following block immediately **before** this comment anchor in `team.php`:
+```
+        <!-- Item
+          <div class="cbp-item">
+            <a class="cbp-caption" href="careers">
+```
+
+Block to insert (note: team.php uses `data-srcset` and `responsively-lazy`, unlike service pages):
+```html
+
+        <!-- Item -->
+         <div class="cbp-item {{ css_classes }}">
+           <a class="cbp-caption" href="profiles/{{ slug }}">
+             <img class="rounded p-2 responsively-lazy" style="border: #898A8D 2px solid;" src="{{ img_med }}" data-srcset="{{ img_med }} 500w, {{ img_med }} 1000w, {{ img_lrg }} 1500w" sizes="(min-width: 993px) 1500px,(min-width: 768px) and (max-width: 992px) 1000px, (max-width: 767px) 500px" alt="{{ display_name }} - {{ title }}">
+           </a>
+             <div class="py-3 blurb">
+               <a href="profiles/{{ slug }}">
+                 <h4 class="h6 text-dark mb-0">{{ display_name }}</h4>
+               </a>
+               <p class="small mb-0">
+                 {{ title }}<br><br>
+               </p>
+             </div>
+         </div>
+         <!-- End Item -->
+```
+
+---
+
+## Step 4 — Update each service page
+
+For each service in the `services` array, insert into the corresponding service page (e.g. `service/massage.php`).
+
+Insert the following block immediately **before** this closing anchor (which ends the practitioner grid in every service page):
+```
+        </div>
+        <!-- End Content -->
+      </div>       
+    </div>
+    <!-- End Portfolio 1 Section -->
+```
+
+Block to insert (note: service pages use `srcset`, not `data-srcset`):
+```html
+
+          <!-- Item -->
+          <div class="cbp-item {{ css_classes }}">
+            <a class="cbp-caption" href="../profiles/{{ slug }}">
+              <img class="rounded p-2" style="border: #898A8D 2px solid;" src="{{ img_med }}" srcset="{{ img_med }} 500w, {{ img_med }} 1000w, {{ img_lrg }} 1500w" sizes="(min-width: 993px) 1500px,(min-width: 768px) and (max-width: 992px) 1000px, (max-width: 767px) 500px" alt="{{ display_name }} - {{ title }}">
+            </a>
+              <div class="py-3 blurb">
+                <a href="../profiles/{{ slug }}">
+                  <h4 class="h6 text-dark mb-0">{{ display_name }}</h4>
+                </a>
+                <p class="small mb-0">
+                   {{ bio.why_choose }} <br><br><br><br><br><br>
+                </p>
+              </div>
+          </div>
+          <!-- End Item -->
+```
+
+---
+
+## Step 5 — Update `sitemap.xml`
+
+Insert the following block immediately **before** `</urlset>` at the end of `sitemap.xml`. Use today's date in ISO 8601 format for `lastmod` (e.g. `2026-05-09T00:00:00+00:00`):
+
+```xml
+  <url>
+    <loc>https://nexushealthclinic.com/profiles/{{ slug }}</loc>
+    <lastmod>{{ TODAY_ISO8601 }}</lastmod>
+    <priority>0.64</priority>
+  </url>
+```
+
+---
+
+## Step 6 — Confirm
+
+After completing all edits, report:
+- The profile page path created
+- Which service pages were updated
+- Confirmation that `team.php` and `sitemap.xml` were updated
+- Remind the user to upload the practitioner's photos to S3 at:
+  - `{{ img_sml }}`
+  - `{{ img_med }}`
+  - `{{ img_lrg }}`

--- a/.claude/commands/add-practitioner.md
+++ b/.claude/commands/add-practitioner.md
@@ -6,7 +6,37 @@ Read that JSON file first, then perform every step below in order.
 
 ## Step 1 — Parse the JSON
 
-Extract all fields. Derive these additional values:
+Extract all fields. Apply this rule to `title` before using it anywhere:
+
+**Title ordering:** If `title` contains multiple titles, reorder them to match this canonical sequence (comma-separated, no `&`):
+1. Chiropractor
+2. Lead Physiotherapist
+3. Physiotherapist
+4. Pelvic Health Physiotherapist
+5. Registered Acupuncturist
+6. Registered Massage Therapist
+7. Physiotherapy Resident
+8. Acupuncture Provider
+
+Any titles not in this list preserve their original relative order and go at the end. Titles are always separated by `, ` (comma + space) — never with `&`.
+
+**SEO description generation:** Always generate `seo.description` fresh — do not use the value from the JSON as-is. Build it from the other JSON fields using this format:
+
+```
+{display_name}, {discipline} at Nexus Massage & Rehab, Yonge & Eglinton Toronto. Specializing in {niche_1} & {niche_2}. Book today.
+```
+
+Rules:
+- **Length:** 145–158 characters (count carefully; adjust niche phrasing to hit the range).
+- **Credential + name:** Use `display_name` (e.g. `Dr. Karen Ngo`).
+- **Discipline:** A short, natural description of their primary role (e.g. `chiropractor & RMT`, `physiotherapist`, `registered acupuncturist`). Derive from `title` and `services`.
+- **Clinic name:** Must include `Nexus Massage & Rehab`.
+- **Location:** Must include `Yonge & Eglinton Toronto` (or `Midtown Toronto`, or both).
+- **Specialization:** 1–2 specific niches drawn from `bio.about` or `bio.specializations` — something distinctive, not just a repeat of the discipline (e.g. `sports rehab`, `pelvic health`, `dancer rehab`, `prenatal care`).
+- **CTA:** End with `Book today.`
+- **Uniqueness:** The generated description must not duplicate any existing practitioner's meta description. Scan the `profiles/` directory for existing pages and check their `<meta name="Description">` tags before finalising.
+
+Derive these additional values:
 - `full_name` = `{first_name} {last_name}`
 - `slug` = `image_key` (used for file paths and URLs, e.g. `ada_chindah`)
 - `img_sml` = `{s3_base_url}/images/profile/sml/{image_key}.jpg`
@@ -301,12 +331,13 @@ where `{service_slug}` is the value from the `services` array (e.g. `massage`, `
 
 ## Step 3 — Update `team.php`
 
-Insert the following block immediately **before** this comment anchor in `team.php`:
+Insert the following block immediately **before** this closing anchor in `team.php` (this places the new entry at the bottom of the healthcare practitioners list, at the end of the Portfolio 1 Section):
 ```
-        <!-- Item
-          <div class="cbp-item">
-            <a class="cbp-caption" href="careers">
+        </div>
+        <!-- End Content -->
 ```
+
+> **Note:** The new practitioner entry must be added to the end of the Portfolio 1 Section — do not insert it anywhere else in the file.
 
 Block to insert (note: team.php uses `data-srcset` and `responsively-lazy`, unlike service pages):
 ```html
@@ -334,7 +365,23 @@ Block to insert (note: team.php uses `data-srcset` and `responsively-lazy`, unli
 
 For each service in the `services` array, insert into the corresponding service page (e.g. `service/massage.php`).
 
-Insert the following block immediately **before** this closing anchor (which ends the practitioner grid in every service page):
+Use the insertion anchor based on the service type:
+
+- **`massage` or `sports-massage`** — insert immediately **before** the Cassandra Kong item:
+```
+          <!-- Item -->
+          <div class="cbp-item rmt">
+            <a class="cbp-caption" href="../profiles/cassandra_kong">
+```
+
+- **`chiropractic`** — insert immediately **before** the Karen Ngo item:
+```
+          <!-- Item -->
+          <div class="cbp-item chiro">
+            <a class="cbp-caption" href="../profiles/karen_ngo">
+```
+
+- **All other services** — insert immediately **before** this closing anchor (which ends the practitioner grid):
 ```
         </div>
         <!-- End Content -->

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.env

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,40 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Nexus Clinic is a PHP-templated marketing website for a massage therapy and rehabilitation clinic in Toronto. It has no backend logic, CMS, or database — pure PHP includes for templating, SASS/Bootstrap 4 for styling, and jQuery for interactivity. Images are served from AWS S3.
+
+## Build & Development
+
+```bash
+npm install          # Install dependencies (first time)
+gulp                 # Watch + compile SASS + start BrowserSync (default task)
+gulp sass            # Compile SASS to assets/css/
+gulp dist            # Production build: copyVendors + minCSS + minJS + minIMG
+```
+
+BrowserSync serves from the project root on `localhost:3000`. There are no tests.
+
+For production, `assets/css/front.min.css` and `assets/js/front.min.js` are the minified outputs used by pages. Run `gulp dist` before deploying.
+
+## Architecture
+
+**PHP templating:** Every `.php` page follows the same structure — `includes/common-header.php` (analytics, fonts, meta tags), `includes/nav.php` (mega menu), page content, then `includes/footer.php`. Pages in subdirectories (e.g., `service/`, `profiles/`) use `../` relative paths for includes.
+
+**SASS:** `assets/include/scss/front.scss` is the main entry point importing all component partials. Custom clinic overrides live in `custom-front.scss` (loaded last). Bootstrap SCSS is compiled separately by the `sass-bootstrap` gulp task (to `assets/vendor/bootstrap/css/`).
+
+**JavaScript:** The `hs.*` component system (from the "Front" HTML template) initializes via data attributes on `$(document).ready()`. Custom tracking and overrides are in `assets/js/custom-front.js`. The minJS gulp task concatenates all `hs.*.js` files + `custom-front.js` into `front.min.js`.
+
+**Staff profiles:** Each practitioner has a dedicated `.php` file in `profiles/`. The team listing page (`team.php`) and nav (`includes/nav.php`) must both be updated when adding/removing staff.
+
+**Booking:** All booking CTAs link to `https://nexusclinic.clinicsense.com/book`. Newsletter signup posts to Mailchimp.
+
+## Key Files
+
+- `includes/nav.php` — main navigation (mega menu); update for any new pages or staff
+- `includes/common-header.php` — GA4, Google Ads, Meta Pixel, Drift chat, all third-party scripts
+- `includes/markup.php` — schema.org structured data (LocalBusiness, OfferCatalog)
+- `assets/include/scss/custom-front.scss` — all clinic-specific style overrides
+- `assets/js/custom-front.js` — custom JS and `handleClick()` event tracking calls

--- a/data/practitioners/_template.json
+++ b/data/practitioners/_template.json
@@ -1,0 +1,26 @@
+{
+  "first_name": "",
+  "last_name": "",
+  "display_name": "",
+  "credential": "",
+  "title": "",
+  "email": "",
+  "image_key": "",
+  "s3_base_url": "https://s3.ca-central-1.amazonaws.com/nexusmassageclinic",
+  "services": [],
+  "hours": [
+    { "day": "", "time": "" }
+  ],
+  "bio": {
+    "about":           "",
+    "cases":           "",
+    "specializations": "",
+    "proud_of":        "",
+    "why_choose":      ""
+  },
+  "seo": {
+    "title":       "",
+    "description": "",
+    "keywords":    ""
+  }
+}

--- a/data/practitioners/_template.json
+++ b/data/practitioners/_template.json
@@ -6,7 +6,7 @@
   "title": "",
   "email": "",
   "image_key": "",
-  "s3_base_url": "https://s3.ca-central-1.amazonaws.com/nexusmassageclinic",
+  "s3_base_url": "https://s3.ca-central-1.amazonaws.com/nexusclinicassets",
   "services": [],
   "hours": [
     { "day": "", "time": "" }

--- a/data/practitioners/jane_doe.json
+++ b/data/practitioners/jane_doe.json
@@ -1,0 +1,29 @@
+{
+  "first_name": "Jane",
+  "last_name": "Doe",
+  "display_name": "Dr. Jane Doe",
+  "credential": "DC, RMT",
+  "title": "Chiropractor & RMT",
+  "email": "jane@nexushealthclinic.com",
+  "image_key": "jane_doe",
+  "s3_base_url": "https://s3.ca-central-1.amazonaws.com/nexusmassageclinic",
+  "services": ["chiropractic", "rmt_massage", "acupuncture"],
+  "hours": [
+    { "day": "Mon", "time": "8:30am - 5:30pm" },
+    { "day": "Wed", "time": "10am - 8pm" },
+    { "day": "Sat", "time": "8:30am - 5pm" },
+    { "day": "Sun", "time": "9:30am - 5pm" }
+  ],
+  "bio": {
+    "about":           "Dr. Jane Doe graduated from the Canadian Memorial Chiropractic College after earning an Honours Degree in Kinesiology at the University of Waterloo. It was at the University of Waterloo when Dr. Doe discovered her passion for dance, specifically latin and old school hip hop. She competed in several local breakdancing battles, as well as, performed for UnitedSalseros at several congresses including the Canada Salsa Congress. Her love and passion for dance and helping people recover through chiropractic care has led her to develop a special interest in working with dancers in the performing arts community. Dr. Doe is now the team chiropractor for the Professional UnitedSalseros dance team. Dr. Doe regularly attends the Performing Arts Medicine Association (PAMA) seminars allowing her to connect with healthcare professionals who share the same interest and tapping into the latest research on ways to benefit the artistic community. Dr. Doe worked with other healthcare professionals conducting screens for dancers of Ballet Jorgen Canada, as well as, setting up outreaches for the street dance community to educate dancers on what they can do to excel in their performance and physical health.\n\nBesides working with the artistic community, Dr. Doe is a Certified First Responder who is experienced working with athletes. She has worked along side with sport teams including the GTA AllStars Football Team, Aurora Barbarians Rugby Team, University of Waterloo Male Varsity Basketball Team, as well as hockey teams at the Stoney Creek Girls Hockey Association Midget AA Showcase Tournament. Dr. Doe loves travelling and learning different cultures and customs around the world. She is a strong advocate for encouraging travellers to give back to the communities they travel through. Dr. Doe has delivered medical care to local residents, as well as, rehabilitation workshops for doctors and physiotherapists at the Orthopaedic and Rehabilitation Hospital in Ho Chi Minh of Vietnam, in the Center of Medical Rehabilitation in Vientiane of Laos, as well as numerous regions in the Dominican Republic. On her free time, you may catch a glimpse of Dr. Doe powerlifting in the gym, on the dance floor at Dovercourt House, or providing a community outreach at a local event near you.",
+    "cases":           "Dr. Jane Doe really enjoy seeing patients from every walks of life. However, her love and passion for dance and helping people recover through chiropractic care has led her to develop a special interest in working with dancers in the performing arts community.",
+    "specializations": "Dr. Jane Doe specialize in spine and joint manual therapy, myofascial release therapy and medical acupuncture. In conjunction with all treatments, patients would be given a tailored functional rehabilitation program to facilitate recovery.",
+    "proud_of":        "Being able to put a smile on my clients' faces as they walk out of my office feeling better and stronger after every visit.",
+    "why_choose":      "Dr. Jane Doe has a strong passion and love for helping people, through non-invasive medicine; efficiently and effectively returning them back to their natural function. As a licensed chiropractor and certified acupuncture provider, Dr. Doe tailors each treatment plan specific to her patients' needs through the most current evidence-based care. She makes your health her priority."
+  },
+  "seo": {
+    "title":       "Jane Doe | Chiropractor & RMT | Nexus Massage & Rehab",
+    "description": "Dr. Jane Doe offers acupuncture, RMT & chiropractic services at Yonge & Eglinton. Learn about the Nexus Massage & Rehab team!",
+    "keywords":    "Chiropractic, chiropractor, massage therapy, massage therapist, RMT, deep massage, rehabilitation, exercise, orthotics, acupuncture, traditional chinese medicine, doctor, trigger point, neck pain, back pain, headaches, adjustments, chiropractor at yonge and eglinton, back pain relief, lower back pain relief, lumbar spine, back strain, herniated disc, neck problems, sore neck, backache, back injury"
+  }
+}

--- a/data/practitioners/jane_doe.json
+++ b/data/practitioners/jane_doe.json
@@ -3,10 +3,10 @@
   "last_name": "Doe",
   "display_name": "Dr. Jane Doe",
   "credential": "DC, RMT",
-  "title": "Chiropractor & RMT",
+  "title": "Chiropractor, Registered Massage Therapist, Acupuncture Provider",
   "email": "jane@nexushealthclinic.com",
   "image_key": "jane_doe",
-  "s3_base_url": "https://s3.ca-central-1.amazonaws.com/nexusmassageclinic",
+  "s3_base_url": "https://s3.ca-central-1.amazonaws.com/nexusclinicassets",
   "services": ["chiropractic", "rmt_massage", "acupuncture"],
   "hours": [
     { "day": "Mon", "time": "8:30am - 5:30pm" },
@@ -23,7 +23,7 @@
   },
   "seo": {
     "title":       "Jane Doe | Chiropractor & RMT | Nexus Massage & Rehab",
-    "description": "Dr. Jane Doe offers acupuncture, RMT & chiropractic services at Yonge & Eglinton. Learn about the Nexus Massage & Rehab team!",
+    "description": "Dr. Jane Doe, chiropractor & RMT at Nexus Massage & Rehab, Yonge & Eglinton Toronto. Specializing in chiropractic, martial arts & dancer rehab. Book today.",
     "keywords":    "Chiropractic, chiropractor, massage therapy, massage therapist, RMT, deep massage, rehabilitation, exercise, orthotics, acupuncture, traditional chinese medicine, doctor, trigger point, neck pain, back pain, headaches, adjustments, chiropractor at yonge and eglinton, back pain relief, lower back pain relief, lumbar spine, back strain, herniated disc, neck problems, sore neck, backache, back injury"
   }
 }


### PR DESCRIPTION
Creates a new /add-practitioner skill

To use this, we need to create a new .json file for the new practitioner being added under data/practitioners/ (i.e. data/practitioners/jane_doe.json)

For now, until we can get a way to directly feed the data received from ProcessStreet / Email, you'll need to duplicate _template.json file, rename it, and then fill it out with the practitioner's information. Afterwards, you can just call `/add-practitioner jane_doe` and it will create the profile page as well as update team page & services page to include the new practitioner. 