### PR TITLE
Create update pricing skill

### DIFF
--- a/.claude/commands/update-pricing.md
+++ b/.claude/commands/update-pricing.md
@@ -1,0 +1,99 @@
+Update service pricing across all relevant pages. The argument is the service slug (e.g. `rmt_massage`).
+
+Read `data/pricing/$ARGUMENTS.json` first, then perform every step below in order.
+
+---
+
+## Available service slugs
+
+| Slug | Service |
+|------|---------|
+| `rmt_massage` | RMT Massage |
+| `hot_stone_massage` | Hot Stone Massage |
+| `manual_lymphatic_drainage` | Manual Lymphatic Drainage Massage |
+| `indian_head_massage` | Indian Head Massage |
+| `sports_massage` | Sports Massage Therapy |
+| `aromatherapy_massage` | Aromatherapy Massage |
+| `prenatal_massage` | Prenatal Massage |
+| `chiropractic` | Chiropractic |
+| `physiotherapy` | Physiotherapy |
+| `pelvic_health_physiotherapy` | Pelvic Health Physiotherapy |
+| `acupuncture` | Acupuncture |
+| `cosmetic_acupuncture` | Cosmetic Acupuncture |
+| `shiatsu_tuina` | Shiatsu / Tuina Massage |
+| `herbs_nutrition` | Herbs & Nutrition |
+| `orthotics` | Orthotics |
+
+---
+
+## Step 1 — Read the JSON
+
+From `data/pricing/$ARGUMENTS.json`, extract:
+- `name` — human-readable service name
+- `heading_text` — text to locate this service's pricing card in each file
+- `files` — list of PHP files to update
+- `prices` — array of `{label, price}` pairs representing the desired state
+- `section_divider` _(optional)_ — text of a `<span class="u-divider ...">` inside the content block that splits it into sub-sections
+- `target_section` _(optional, only used when `section_divider` is present)_ — either `"before"` or `"after"`, indicating which sub-section to update
+
+Any field starting with `_` is a note for context only — do not act on it directly.
+
+---
+
+## Step 2 — Update each file
+
+For each file path in `files`, read the file and perform the following:
+
+### 2a — Locate the pricing card
+
+Find the `<strong>` heading element that contains `heading_text`. Rules for matching:
+- Case-insensitive
+- Strip any `<br>` or `<br/>` tags from the element before comparing
+- For `heading_text = "PHYSIOTHERAPY"`: match the first card whose heading does **not** also contain "PELVIC"
+- For `heading_text = "ACUPUNCTURE"`: match the card whose heading does **not** also contain "HERBS"
+- For `heading_text = "CHIROPRACTIC"`: match only if not inside a sentence (it should be the entire content of the `<strong>` element, not part of a paragraph)
+
+### 2b — Find the content block
+
+Within that pricing card, find the `<!-- Content -->` comment. The price rows are in the `<ul class="list-unstyled">` block between `<!-- Content -->` and `<!-- End Content -->`.
+
+### 2c — Narrow to the target sub-section (if applicable)
+
+If `section_divider` is present in the JSON:
+
+1. Within the `<ul class="list-unstyled">` block, locate the `<span class="u-divider ...">` element whose text matches `section_divider`.
+2. If `target_section` is `"before"`: only consider `<li>` rows that appear **before** that `<span>`.
+3. If `target_section` is `"after"`: only consider `<li>` rows that appear **after** that `<span>`.
+4. If no divider is found in a file (e.g. `service/acupuncture.php` has no cosmetic divider), treat the entire content block as the target and update all matching rows normally.
+
+If `section_divider` is absent, the entire content block is the target.
+
+### 2d — Update price rows
+
+For each `{label, price}` pair in `prices`:
+
+1. Find the `<li class="u-pricing-v2__list-item ...">` element within the target sub-section whose text matches `label`. When matching:
+   - Normalize: treat a hyphen (`-`) and a space as equivalent (e.g. `Follow-Up` matches `Follow Up`)
+   - Match case-insensitively
+
+2. Replace only the content inside the `<strong>...</strong>` tag on that line with the new `price` value. Preserve everything else on the line exactly (indentation, class names, the label text, ` - `, surrounding HTML).
+
+3. If no matching row is found for a label, **skip it** and note it in the final report — do not add a new row.
+
+### 2e — Do not touch
+
+Leave these unchanged in every file:
+- `<li>` rows containing `&nbsp` (padding rows)
+- `<span class="u-divider ...">` sub-section dividers (e.g., `TELEHEALTH`, `COSMETIC ACUPUNCTURE`)
+- `<li class="small ...">` note/footnote rows
+- All HTML outside the `<!-- Content -->` … `<!-- End Content -->` block
+
+---
+
+## Step 3 — Confirm
+
+After updating all files, report:
+- Which files were updated
+- Which price rows were changed (old value → new value) per file
+- Any labels from the JSON that were **not found** in a file (skipped)
+- Remind the user to run `gulp dist` before deploying to regenerate minified assets

--- a/data/pricing/acupuncture.json
+++ b/data/pricing/acupuncture.json
@@ -1,0 +1,15 @@
+{
+  "name": "Acupuncture",
+  "heading_text": "ACUPUNCTURE",
+  "_heading_note": "Match the heading that does NOT contain 'HERBS'.",
+  "files": ["pricing.php", "service/acupuncture.php"],
+  "section_divider": "COSMETIC ACUPUNCTURE",
+  "target_section": "before",
+  "_note": "pricing.php has a COSMETIC ACUPUNCTURE sub-section after a divider span. This file targets only the rows BEFORE that divider. service/acupuncture.php has no divider so all rows are updated.",
+  "prices": [
+    {"label": "15 Min Consultation", "price": "FREE"},
+    {"label": "Initial Assessment", "price": "$140"},
+    {"label": "60 Min Follow-Up", "price": "$115"},
+    {"label": "75 Min Follow-Up", "price": "$130"}
+  ]
+}

--- a/data/pricing/aromatherapy_massage.json
+++ b/data/pricing/aromatherapy_massage.json
@@ -1,0 +1,13 @@
+{
+  "name": "Aromatherapy Massage",
+  "heading_text": "AROMATHERAPY MASSAGE",
+  "files": ["pricing.php", "service/massage.php"],
+  "prices": [
+    {"label": "30 Min Session", "price": "$100 + HST"},
+    {"label": "45 Min Session", "price": "$115 + HST"},
+    {"label": "60 Min Session", "price": "$135 + HST"},
+    {"label": "75 Min Session", "price": "$165 + HST"},
+    {"label": "90 Min Session", "price": "$190 + HST"},
+    {"label": "120 Min Session", "price": "$260 + HST"}
+  ]
+}

--- a/data/pricing/chiropractic.json
+++ b/data/pricing/chiropractic.json
@@ -1,0 +1,12 @@
+{
+  "name": "Chiropractic",
+  "heading_text": "CHIROPRACTIC",
+  "files": ["pricing.php", "service/chiropractic.php"],
+  "_note": "pricing.php uses 'Follow-Up' (hyphen); service/chiropractic.php uses 'Follow Up' (space). The skill normalizes hyphens/spaces when matching labels.",
+  "prices": [
+    {"label": "15 Min Consultation", "price": "FREE"},
+    {"label": "Initial Assessment", "price": "$135"},
+    {"label": "20 Min Follow-Up", "price": "$90"},
+    {"label": "40 Min Follow-Up", "price": "$115"}
+  ]
+}

--- a/data/pricing/cosmetic_acupuncture.json
+++ b/data/pricing/cosmetic_acupuncture.json
@@ -1,0 +1,13 @@
+{
+  "name": "Cosmetic Acupuncture",
+  "heading_text": "ACUPUNCTURE",
+  "_heading_note": "Cosmetic Acupuncture lives inside the ACUPUNCTURE pricing card in pricing.php, after the COSMETIC ACUPUNCTURE divider span.",
+  "files": ["pricing.php"],
+  "section_divider": "COSMETIC ACUPUNCTURE",
+  "target_section": "after",
+  "prices": [
+    {"label": "15 Min Consultation", "price": "FREE"},
+    {"label": "Initial Assessment", "price": "$140"},
+    {"label": "60 Min Follow-Up", "price": "$115"}
+  ]
+}

--- a/data/pricing/herbs_nutrition.json
+++ b/data/pricing/herbs_nutrition.json
@@ -1,0 +1,10 @@
+{
+  "name": "Herbs & Nutrition",
+  "heading_text": "HERBS & NUTRITION",
+  "files": ["pricing.php", "service/acupuncture.php"],
+  "_note": "Prices have no HST as this service cannot be claimed under Acupuncture insurance.",
+  "prices": [
+    {"label": "Initial Assessment", "price": "$110"},
+    {"label": "30 Min Follow-Up", "price": "$95"}
+  ]
+}

--- a/data/pricing/hot_stone_massage.json
+++ b/data/pricing/hot_stone_massage.json
@@ -1,0 +1,13 @@
+{
+  "name": "Hot Stone Massage",
+  "heading_text": "HOT STONE MASSAGE",
+  "files": ["pricing.php", "service/massage.php"],
+  "prices": [
+    {"label": "30 Min Session", "price": "$110 + HST"},
+    {"label": "45 Min Session", "price": "$125 + HST"},
+    {"label": "60 Min Session", "price": "$150 + HST"},
+    {"label": "75 Min Session", "price": "$185 + HST"},
+    {"label": "90 Min Session", "price": "$210 + HST"},
+    {"label": "120 Min Session", "price": "$280 + HST"}
+  ]
+}

--- a/data/pricing/indian_head_massage.json
+++ b/data/pricing/indian_head_massage.json
@@ -1,0 +1,10 @@
+{
+  "name": "Indian Head Massage",
+  "heading_text": "INDIAN HEAD MASSAGE",
+  "files": ["pricing.php", "service/massage.php"],
+  "prices": [
+    {"label": "30 Min Session", "price": "$85 + HST"},
+    {"label": "45 Min Session", "price": "$100 + HST"},
+    {"label": "60 Min Session", "price": "$120 + HST"}
+  ]
+}

--- a/data/pricing/manual_lymphatic_drainage.json
+++ b/data/pricing/manual_lymphatic_drainage.json
@@ -1,0 +1,13 @@
+{
+  "name": "Manual Lymphatic Drainage Massage",
+  "heading_text": "MANUAL LYMPHATIC DRAINAGE MASSAGE",
+  "files": ["pricing.php", "service/massage.php"],
+  "prices": [
+    {"label": "30 Min Session", "price": "$100 + HST"},
+    {"label": "45 Min Session", "price": "$115 + HST"},
+    {"label": "60 Min Session", "price": "$135 + HST"},
+    {"label": "75 Min Session", "price": "$165 + HST"},
+    {"label": "90 Min Session", "price": "$185 + HST"},
+    {"label": "120 Min Session", "price": "$260 + HST"}
+  ]
+}

--- a/data/pricing/orthotics.json
+++ b/data/pricing/orthotics.json
@@ -1,0 +1,8 @@
+{
+  "name": "Orthotics",
+  "heading_text": "ORTHOTICS",
+  "files": ["pricing.php", "service/orthotics.php"],
+  "prices": [
+    {"label": "Custom Orthotics", "price": "$500"}
+  ]
+}

--- a/data/pricing/pelvic_health_physiotherapy.json
+++ b/data/pricing/pelvic_health_physiotherapy.json
@@ -1,0 +1,12 @@
+{
+  "name": "Pelvic Health Physiotherapy",
+  "heading_text": "PELVIC HEALTH PHYSIOTHERAPY",
+  "files": ["pricing.php", "service/physiotherapy.php"],
+  "_note": "pricing.php includes '60 Min Follow-Up - $190' but service/physiotherapy.php is missing this row. The skill will update rows that exist in each file and skip labels not found.",
+  "prices": [
+    {"label": "15 Min Consultation", "price": "FREE"},
+    {"label": "Initial Assessment", "price": "$170"},
+    {"label": "40 Min Follow-Up", "price": "$140"},
+    {"label": "60 Min Follow-Up", "price": "$190"}
+  ]
+}

--- a/data/pricing/physiotherapy.json
+++ b/data/pricing/physiotherapy.json
@@ -1,0 +1,16 @@
+{
+  "name": "Physiotherapy",
+  "heading_text": "PHYSIOTHERAPY",
+  "_heading_note": "Match the heading that does NOT contain 'PELVIC'. In service/physiotherapy.php this is the first pricing card.",
+  "files": ["pricing.php", "service/physiotherapy.php", "service/telehealth.php"],
+  "_note": "pricing.php uses 'Follow-Up' (hyphen); service pages use 'Follow Up' (space). The skill normalizes hyphens/spaces when matching labels. service/telehealth.php only shows the virtual/telehealth rows.",
+  "prices": [
+    {"label": "15 Min Consultation", "price": "FREE"},
+    {"label": "Initial Assessment", "price": "$135"},
+    {"label": "20 Min Follow-Up", "price": "$90"},
+    {"label": "40 Min Follow-Up", "price": "$115"},
+    {"label": "Virtual Initial Assessment", "price": "$135"},
+    {"label": "20 Min Virtual Follow-Up", "price": "$90"},
+    {"label": "40 Min Virtual Follow-Up", "price": "$115"}
+  ]
+}

--- a/data/pricing/prenatal_massage.json
+++ b/data/pricing/prenatal_massage.json
@@ -1,0 +1,13 @@
+{
+  "name": "Prenatal Massage",
+  "heading_text": "PRENATAL MASSAGE",
+  "files": ["pricing.php", "service/massage.php"],
+  "prices": [
+    {"label": "30 Min Session", "price": "$85 + HST"},
+    {"label": "45 Min Session", "price": "$100 + HST"},
+    {"label": "60 Min Session", "price": "$120 + HST"},
+    {"label": "75 Min Session", "price": "$145 + HST"},
+    {"label": "90 Min Session", "price": "$170 + HST"},
+    {"label": "120 Min Session", "price": "$240 + HST"}
+  ]
+}

--- a/data/pricing/rmt_massage.json
+++ b/data/pricing/rmt_massage.json
@@ -1,0 +1,13 @@
+{
+  "name": "RMT Massage",
+  "heading_text": "RMT MASSAGE",
+  "files": ["pricing.php", "service/massage.php"],
+  "prices": [
+    {"label": "30 Min Session", "price": "$85 + HST"},
+    {"label": "45 Min Session", "price": "$100 + HST"},
+    {"label": "60 Min Session", "price": "$120 + HST"},
+    {"label": "75 Min Session", "price": "$145 + HST"},
+    {"label": "90 Min Session", "price": "$170 + HST"},
+    {"label": "120 Min Session", "price": "$240 + HST"}
+  ]
+}

--- a/data/pricing/shiatsu_tuina.json
+++ b/data/pricing/shiatsu_tuina.json
@@ -1,0 +1,11 @@
+{
+  "name": "Shiatsu / Tuina Massage",
+  "heading_text": "SHIATSU / TUINA MASSAGE",
+  "files": ["pricing.php"],
+  "_note": "This service only appears on pricing.php. Prices are listed as Follow-Up sessions (no HST) as this service is billed under Acupuncture insurance.",
+  "prices": [
+    {"label": "30 Min Follow-Up", "price": "$85"},
+    {"label": "45 Min Follow-Up", "price": "$100"},
+    {"label": "60 Min Follow-Up", "price": "$120"}
+  ]
+}

--- a/data/pricing/sports_massage.json
+++ b/data/pricing/sports_massage.json
@@ -1,0 +1,11 @@
+{
+  "name": "Sports Massage Therapy",
+  "heading_text": "SPORTS MASSAGE THERAPY",
+  "files": ["pricing.php", "service/massage.php", "service/sports-massage.php"],
+  "_note": "service/sports-massage.php shows Initial Assessment without '+ HST' — this is a known inconsistency. Running this skill will standardize all files to match the prices below.",
+  "prices": [
+    {"label": "Initial Assessment", "price": "$120 + HST"},
+    {"label": "30 Min Session", "price": "$85 + HST"},
+    {"label": "45 Min Session", "price": "$100 + HST"}
+  ]
+}


### PR DESCRIPTION
Creates a new `/update-pricing` skill

For this, we created a new .json file for each of the services offered by Nexus. This file will act as the source of truth for how the other services should pull the pricing information. When the skill is called, it will make the necessary price updates to the pricing page as well as the prices listed in their respective services page. 

Here are the instructions for how to use this skill
1. Make the necessary price adjustments in `/data/pricing/$SLUG.json` 
2. Call `/update-pricing $SLUG` to invoke the skill (i.e. `/update-pricing hot_stone_massage`) 